### PR TITLE
Update rate limit for general config as per Carly Request

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ async def on_ready() -> None:
         916104906065207346)  # This channel ID is the main A2C one
 
     Config.Slowmode.channels[f"{Config.ChannelIDs.general.id}"] = Config.Slowmode.ChannelConfig(
-        3, 9, 2.0)
+        4, 12, 1.25)
     # Config.Slowmode.channels[f"{Config.ChannelIDs.college_talk.id}"] = Config.Slowmode.ChannelConfig(
     #     3, 9, 2.0)
 


### PR DESCRIPTION
Updating default gen-chat rate limit to 4,12,1.25